### PR TITLE
Remove redundant class attributes declarations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,7 @@
     -   id: autopep8
         args:
         - '-i'
+-   repo: https://github.com/PyCQA/autoflake
+    rev: v2.0.0
+    hooks:
+    -   id: autoflake

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.autoflake]
+remove-all-unused-imports = true

--- a/src/actions/action.py
+++ b/src/actions/action.py
@@ -1,4 +1,4 @@
-from src.common.serializable import Serializable, Properties
+from src.common.serializable import Serializable
 
 
 class Action(Serializable):

--- a/src/actions/action.py
+++ b/src/actions/action.py
@@ -6,8 +6,6 @@ class Action(Serializable):
     Represents abstract object responsible for interacting
     with a `scene`.
     """
-    base: str
-    properties: Properties
 
     def __init__(self) -> None:
         super().__init__(__class__.__name__)

--- a/src/actions/attacks/slash.py
+++ b/src/actions/attacks/slash.py
@@ -2,7 +2,6 @@ from src.common.enums import Direction
 from src.common.point import Point
 from src.actions.action import Action
 from src.actions.deal_dmg import DealDmg
-from src.common.serializable import Properties
 from src.objects.object import Object
 from src.objects.npcs.enemy import Enemy
 

--- a/src/actions/attacks/slash.py
+++ b/src/actions/attacks/slash.py
@@ -13,8 +13,6 @@ class Slash(Action):
     """
     Simple action for attacking.
     """
-    base: str
-    properties: Properties
     object: Object
 
     def __init__(self, object: Object, direction: Direction) -> None:

--- a/src/actions/deal_dmg.py
+++ b/src/actions/deal_dmg.py
@@ -10,8 +10,6 @@ class DealDmg(Action):
     """
     Simple action for dealing damage.
     """
-    base: str
-    properties: Properties
     target: Union['Agent', NPC]
 
     def __init__(self, target: Union['Agent', NPC], dmg: int) -> None:

--- a/src/actions/deal_dmg.py
+++ b/src/actions/deal_dmg.py
@@ -2,7 +2,6 @@ from typing import Union
 
 from src.actions.action import Action
 from src.actions.destroy import Destroy
-from src.common.serializable import Properties
 from src.objects.npc import NPC
 
 

--- a/src/actions/destroy.py
+++ b/src/actions/destroy.py
@@ -10,8 +10,6 @@ class Destroy(Action):
     """
     Simple action for dying.
     """
-    base: str
-    properties: Properties
     object: Union['Agent', NPC]
 
     def __init__(self, object: Union['Agent', NPC]) -> None:

--- a/src/actions/destroy.py
+++ b/src/actions/destroy.py
@@ -2,7 +2,6 @@ from typing import Union
 
 
 from src.actions.action import Action
-from src.common.serializable import Properties
 from src.objects.npc import NPC
 
 

--- a/src/actions/idle.py
+++ b/src/actions/idle.py
@@ -7,8 +7,6 @@ class Idle(Action):
     """
     Simple action for idling.
     """
-    base: str
-    properties: Properties
     object: Object
 
     def __init__(self, object: Object) -> None:

--- a/src/actions/idle.py
+++ b/src/actions/idle.py
@@ -1,5 +1,4 @@
 from src.actions.action import Action
-from src.common.serializable import Properties
 from src.objects.object import Object
 
 

--- a/src/actions/move.py
+++ b/src/actions/move.py
@@ -10,8 +10,6 @@ class Move(Action):
     Simple action for changing position of `Agent`. It does not log anything
     in case the movement was not possible(destination is not walkable etc).
     """
-    base: str
-    properties: Properties
     object: Object
 
     def __init__(self, object: Object, direction: Direction) -> None:

--- a/src/actions/move.py
+++ b/src/actions/move.py
@@ -1,7 +1,6 @@
 from src.common.enums import Direction
 from src.common.point import Point
 from src.actions.action import Action
-from src.common.serializable import Properties
 from src.objects.object import Object
 
 

--- a/src/actions/nearby_objects.py
+++ b/src/actions/nearby_objects.py
@@ -9,8 +9,6 @@ class NearbyObjects(Action):
     """
     Action to retrieve nearby objects within the range of the triggering object
     """
-    base: str
-    properties: Properties
     object: Object
     range: int
 

--- a/src/actions/nearby_objects.py
+++ b/src/actions/nearby_objects.py
@@ -1,6 +1,5 @@
 from src.actions.action import Action
 from src.common.point import Point
-from src.common.serializable import Properties
 from src.objects.interactive_object import InteractiveObject
 from src.objects.object import Object
 

--- a/src/actions/next_scene.py
+++ b/src/actions/next_scene.py
@@ -7,8 +7,6 @@ class NextScene(Action):
     """
     `Action` used to create next scene. Called on collision by `Portal`.
     """
-    base: str
-    properties: Properties
     runtime: 'Runtime'
 
     def __init__(self, runtime: 'Runtime') -> None:

--- a/src/actions/next_scene.py
+++ b/src/actions/next_scene.py
@@ -1,6 +1,5 @@
 from src.scene import Scene
 from src.actions.action import Action
-from src.common.serializable import Properties
 
 
 class NextScene(Action):

--- a/src/actions/use.py
+++ b/src/actions/use.py
@@ -9,8 +9,6 @@ class Use(Action):
     """
     An action that provides the opportunity to interact with another object
     """
-    base: str
-    properties: Properties
     triggering_object: Object
     object_id: int  # object id for interaction
     action: str  # name of the action method to call

--- a/src/actions/use.py
+++ b/src/actions/use.py
@@ -1,6 +1,5 @@
 from src.actions.action import Action
 from src.common.point import Point
-from src.common.serializable import Properties
 from src.objects.interactive_object import InteractiveObject
 from src.objects.object import Object
 

--- a/src/actions/wait_for_code.py
+++ b/src/actions/wait_for_code.py
@@ -7,9 +7,7 @@ class WaitForCode(Action):
     Action blocking execution of the runtime until it reads
     message from `stdin` saying that the `code` was uploaded
     """
-    base: str
     interactive: bool
-    properties: Properties
 
     def __init__(self, interactive: bool) -> None:
         super().__init__()

--- a/src/actions/wait_for_code.py
+++ b/src/actions/wait_for_code.py
@@ -1,5 +1,4 @@
 from src.actions.action import Action
-from src.common.serializable import Properties
 
 
 class WaitForCode(Action):

--- a/src/actions/wave.py
+++ b/src/actions/wave.py
@@ -6,8 +6,6 @@ class Wave(Action):
     """
     Simple action for playing an animation on frontend.
     """
-    base: str
-    properties: Properties
 
     def __init__(self, agent: 'Agent') -> None:
         super().__init__()

--- a/src/actions/wave.py
+++ b/src/actions/wave.py
@@ -1,5 +1,4 @@
 from src.actions.action import Action
-from src.common.serializable import Properties
 
 
 class Wave(Action):

--- a/src/objects/agent.py
+++ b/src/objects/agent.py
@@ -1,4 +1,3 @@
-from src.common.exec_interrupt import MapExit
 from src.actions.use import Use
 from src.actions.move import Move
 from src.actions.nearby_objects import NearbyObjects
@@ -8,7 +7,6 @@ from src.actions.attacks.slash import Slash
 from src.common.enums import Direction
 from src.common.point import Point
 from src.objects.object import Object
-from src.common.serializable import Properties
 from src.actions.wait_for_code import WaitForCode
 
 AGENT_HP = 100

--- a/src/objects/agent.py
+++ b/src/objects/agent.py
@@ -18,10 +18,6 @@ class Agent(Object):
     """
     Simple agent existing in a `scene`.
     """
-    base: str
-    properties: Properties
-    scene: 'Scene'
-    walkable: bool
     items: list
     hp: int
 

--- a/src/objects/floor.py
+++ b/src/objects/floor.py
@@ -1,6 +1,5 @@
 from src.common.point import Point
 from src.objects.object import Object
-from src.common.serializable import Properties
 
 
 class Floor(Object):

--- a/src/objects/floor.py
+++ b/src/objects/floor.py
@@ -7,10 +7,6 @@ class Floor(Object):
     """
     Simple walkable `Object`.
     """
-    base: str
-    properties: Properties
-    scene: 'Scene'
-    walkable: bool
 
     def __init__(self, scene: 'Scene', position: Point = Point(0, 0)) -> None:
         super().__init__(position, scene)

--- a/src/objects/interactive_object.py
+++ b/src/objects/interactive_object.py
@@ -1,5 +1,4 @@
 from src.common.point import Point
-from src.common.serializable import Properties
 from src.objects.object import Object
 
 

--- a/src/objects/interactive_object.py
+++ b/src/objects/interactive_object.py
@@ -7,8 +7,6 @@ class InteractiveObject(Object):
     """
     Abstract represents object that can interact with each other
     """
-    base: str
-    properties: Properties
     can_pick_up: bool
 
     def __init__(self, position: Point, scene: 'Scene') -> None:

--- a/src/objects/npc.py
+++ b/src/objects/npc.py
@@ -4,7 +4,6 @@ from transitions import Machine
 
 from src.common.point import Point
 from src.objects.object import Object
-from src.common.serializable import Properties
 from src.actions.move import Move
 from src.actions.idle import Idle
 from src.common.enums import Direction
@@ -14,10 +13,6 @@ class NPC(Object):
     """
     NPC interface.
     """
-    base: str
-    properties: Properties
-    scene: 'Scene'
-    walkable: bool
     machine: Machine
     hp: int
 

--- a/src/objects/npcs/enemies/training_dummy.py
+++ b/src/objects/npcs/enemies/training_dummy.py
@@ -2,7 +2,6 @@ from transitions import Machine, State
 
 from src.objects.npcs.enemy import Enemy
 from src.common.point import Point
-from src.common.serializable import Properties
 
 TRAINING_DUMMY_HP = 1000000
 TRAINING_DUMMY_STATES = [State(name='idle')]

--- a/src/objects/npcs/enemies/training_dummy.py
+++ b/src/objects/npcs/enemies/training_dummy.py
@@ -12,10 +12,6 @@ class TrainingDummy(Enemy):
     """
     Enemy that does not do anything.
     """
-    base: str
-    properties: Properties
-    scene: 'Scene'
-    walkable: bool
 
     def __init__(self, scene: 'Scene', position: Point) -> None:
         super().__init__(scene, position, TRAINING_DUMMY_HP,

--- a/src/objects/npcs/enemy.py
+++ b/src/objects/npcs/enemy.py
@@ -2,19 +2,12 @@ from transitions import Machine
 
 from src.objects.npc import NPC
 from src.common.point import Point
-from src.common.serializable import Properties
 
 
 class Enemy(NPC):
     """
     Enemy interface.
     """
-    base: str
-    properties: Properties
-    scene: 'Scene'
-    walkable: bool
-    machine: Machine
-    hp: int
 
     def __init__(self, scene: 'Scene', position: Point, hp: int, machine: Machine) -> None:
         super().__init__(scene, position, hp, machine)

--- a/src/objects/object.py
+++ b/src/objects/object.py
@@ -1,5 +1,5 @@
 from src.common.point import Point
-from src.common.serializable import Serializable, Properties
+from src.common.serializable import Serializable
 
 
 class Object(Serializable):

--- a/src/objects/object.py
+++ b/src/objects/object.py
@@ -7,8 +7,6 @@ class Object(Serializable):
     Abstract object existing in a `scene`. Represents part of scene's state,
     in contrast to `Action` which represents only modifications of the state.
     """
-    base: str
-    properties: Properties
     scene: 'Scene'
     walkable: bool
 

--- a/src/objects/portal.py
+++ b/src/objects/portal.py
@@ -8,10 +8,6 @@ class Portal(Object):
     """
     `Object` allowing the player to move to a next `scene`.
     """
-    base: str
-    properties: Properties
-    scene: 'Scene'
-    walkable: bool
 
     def __init__(self, scene: 'Scene', position: Point = Point(0, 0)) -> None:
         super().__init__(position, scene)

--- a/src/objects/portal.py
+++ b/src/objects/portal.py
@@ -1,7 +1,6 @@
 from src.common.exec_interrupt import MapExit
 from src.common.point import Point
 from src.objects.object import Object
-from src.common.serializable import Properties
 
 
 class Portal(Object):


### PR DESCRIPTION
There are many redundant class attributes declarations that are inherited anyways. 
It greatly clutters the code and makes it less readable.